### PR TITLE
fix: typo in add r1 to r0 log

### DIFF
--- a/src/vm/CPU.ts
+++ b/src/vm/CPU.ts
@@ -116,7 +116,7 @@ while (true) {
     case Instruction.ADD_R1_TO_R0:
       const oldR0 = R0;
       setFlags((R0 = R0 + R1));
-      logState(`Add R1(${R1}) + R1(${oldR0}) => R0(${R0})`);
+      logState(`Add R1(${R1}) + R0(${oldR0}) => R0(${R0})`);
       break;
     case Instruction.MOVE_R0_TO_R1:
       R1 = R0;


### PR DESCRIPTION
Hi! Fix for a typo in:

<img width="1035" alt="Screenshot 2023-09-22 at 02 17 36" src="https://github.com/mhevery/JavaScriptVM_under_the_hood/assets/5403694/8b832dbd-450e-4345-902d-76f7cd9c5cf7">

... so that it becomes:

<img width="924" alt="Screenshot 2023-09-22 at 02 06 39" src="https://github.com/mhevery/JavaScriptVM_under_the_hood/assets/5403694/ff301f70-a8e0-4824-bbb3-cf5c64d9eeed">

This is the closest I will ever be to fixing Pentium floating point bug :D